### PR TITLE
Remove imports so we don't need a transpilation step

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
-import fs from "fs";
-import jsdom from "jsdom";
-import path from "path";
-import PercyAgent from "@percy/agent";
-import slug from "slug";
-import { Webdriver } from "wd";
+const fs = require("fs");
+const jsdom = require("jsdom");
+const path = require("path");
+const PercyAgent = require("@percy/agent");
+const slug = require("slug");
+const { Webdriver } = require("wd");
 
 // Webdriver extension for taking Percy snapshots
 //

--- a/package-lock.json
+++ b/package-lock.json
@@ -2770,6 +2770,14 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
     },
+    "slug": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/slug/-/slug-1.1.0.tgz",
+      "integrity": "sha512-NuIOjDQeTMPm+/AUIHJ5636mF3jOsYLFnoEErl9Tdpt4kpt4fOrAJxscH9mUgX1LtPaEqgPCawBg7A4yhoSWRg==",
+      "requires": {
+        "unicode": ">= 0.3.1"
+      }
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -3174,6 +3182,11 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "unicode": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/unicode/-/unicode-11.0.1.tgz",
+      "integrity": "sha512-+cHtykLb+eF1yrSLWTwcYBrqJkTfX7Quoyg7Juhe6uylF43ZbMdxMuSHNYlnyLT8T7POAvavgBthzUF9AIaQvQ=="
     },
     "union-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -22,10 +22,14 @@
   "bugs": {
     "url": "https://github.com/percy/percy-appium/issues"
   },
+  "engines": {
+    "node": ">=8.2.0"
+  },
   "homepage": "https://github.com/percy/percy-appium#readme",
   "dependencies": {
     "@percy/agent": "^0.7.2",
     "jsdom": "^15.1.1",
+    "slug": "^1.1.0",
     "wd": "^1.11.2"
   }
 }


### PR DESCRIPTION
## What is this?

Appium requires node 8 (and so do we) so we can remove the need for transpiling
this code by removing the ES6 imports (which aren't supported in Node yet).

Thankfully `aysnc` / `await` is in Node 8 & we heavily rely on that.