### PR TITLE
Add option to cut off status bar.

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ Webdriver.prototype.percySnapshot = async function percySnapshot(name, options =
   const base64Data = rawBase64Data.replace(/([ \r\n]+)/g, '');
 
   // Create styles for a DOM element that will render the screenshot
+  // `customCss` needs to be configured similar to below. (ex: `margin: 10px;`)
   const css = `
     background-image: url('data:image/png;base64,${base64Data}');
     background-repeat: no-repeat;

--- a/index.js
+++ b/index.js
@@ -25,7 +25,10 @@ Webdriver.prototype.percySnapshot = async function percySnapshot(name, options =
   // Instead of creating a whole build with a seperate info.plist to
   // be able to hide the status bar you can set this option to push
   // the screenshot up and cut off the status bar before it's sent
-  const marginTop = options.hideStatusBar ? '-40' : '0';
+  var marginTop = 0;
+  if (options.hideStatusBar) {
+    dimensions.height > 700 ? (marginTop = '-10%') : (marginTop = '-5%');
+  }
 
   // Get the base64-encoded screenshot of the app
   const rawBase64Data = await this.takeScreenshot();

--- a/index.js
+++ b/index.js
@@ -22,13 +22,6 @@ Webdriver.prototype.percySnapshot = async function percySnapshot(name, options =
   // Get the dimensions of the device so we can render the screenshot
   // at the correct size
   const dimensions = await this.getWindowSize();
-  // Instead of creating a whole build with a seperate info.plist to
-  // be able to hide the status bar you can set this option to push
-  // the screenshot up and cut off the status bar before it's sent
-  var marginTop = 0;
-  if (options.hideStatusBar) {
-    dimensions.height > 700 ? (marginTop = '-10%') : (marginTop = '-5%');
-  }
 
   // Get the base64-encoded screenshot of the app
   const rawBase64Data = await this.takeScreenshot();
@@ -43,7 +36,7 @@ Webdriver.prototype.percySnapshot = async function percySnapshot(name, options =
     background-size: contain;
     height: ${dimensions.height}px;
     width: ${dimensions.width}px;
-    margin-top: ${marginTop};
+    ${options.customCss}
   `;
 
   // Percy Agent and JSDOM don't play nicely together if you try to use a

--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@ Webdriver.prototype.percySnapshot = async function percySnapshot(name, options =
   // Get the dimensions of the device so we can render the screenshot
   // at the correct size
   const dimensions = await this.getWindowSize();
+  // Instead of creating a whole build with a seperate info.plist to
+  // be able to hide the status bar you can set this option to push
+  // the screenshot up and cut off the status bar before it's sent
+  const marginTop = options.hideStatusBar ? '-40' : '0';
 
   // Get the base64-encoded screenshot of the app
   const rawBase64Data = await this.takeScreenshot();

--- a/index.js
+++ b/index.js
@@ -22,13 +22,6 @@ Webdriver.prototype.percySnapshot = async function percySnapshot(name, options =
   // Get the dimensions of the device so we can render the screenshot
   // at the correct size
   const dimensions = await this.getWindowSize();
-  // Instead of creating a whole build with a seperate info.plist to
-  // be able to hide the status bar you can set this option to push
-  // the screenshot up and cut off the status bar before it's sent
-  var marginTop = 0;
-  if (options.hideStatusBar) {
-    dimensions.height > 700 ? (marginTop = '-10%') : (marginTop = '-5%');
-  }
 
   // Get the base64-encoded screenshot of the app
   const rawBase64Data = await this.takeScreenshot();

--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@ Webdriver.prototype.percySnapshot = async function percySnapshot(name, options =
   // Get the dimensions of the device so we can render the screenshot
   // at the correct size
   const dimensions = await this.getWindowSize();
+  // Instead of creating a whole build with a seperate info.plist to
+  // be able to hide the status bar you can set this option to push
+  // the screenshot up and cut off the status bar before it's sent
+  const marginTop = options.hideStatusBar ? '-40' : '0';
 
   // Get the base64-encoded screenshot of the app
   const rawBase64Data = await this.takeScreenshot();
@@ -36,6 +40,7 @@ Webdriver.prototype.percySnapshot = async function percySnapshot(name, options =
     background-size: contain;
     height: ${dimensions.height}px;
     width: ${dimensions.width}px;
+    margin-top: ${marginTop}px;
   `;
 
   // Percy Agent and JSDOM don't play nicely together if you try to use a

--- a/index.js
+++ b/index.js
@@ -25,7 +25,10 @@ Webdriver.prototype.percySnapshot = async function percySnapshot(name, options =
   // Instead of creating a whole build with a seperate info.plist to
   // be able to hide the status bar you can set this option to push
   // the screenshot up and cut off the status bar before it's sent
-  const marginTop = options.hideStatusBar ? '-40' : '0';
+  var marginTop = 0;
+  if (options.hideStatusBar) {
+    dimensions.height > 700 ? (marginTop = '-10%') : (marginTop = '-5%');
+  }
 
   // Get the base64-encoded screenshot of the app
   const rawBase64Data = await this.takeScreenshot();
@@ -40,7 +43,7 @@ Webdriver.prototype.percySnapshot = async function percySnapshot(name, options =
     background-size: contain;
     height: ${dimensions.height}px;
     width: ${dimensions.width}px;
-    margin-top: ${marginTop}px;
+    margin-top: ${marginTop};
   `;
 
   // Percy Agent and JSDOM don't play nicely together if you try to use a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/appium-wd",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Webdriver & Appium client library for visual regression testing with Percy",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This adds what @Robdel12 is adding in [his branch](https://github.com/percy/percy-appium-wd/tree/rd/post-from-node) and adds the option to modify the screenshot to cut off the status bar.

If you wanted to do this via apple you'd have to [set the preference in a the `info.plist` when you build the app.] To circumvent this, I added some easy margin to push the taken screenshot up thus pushing the status bar out of view and adds one less variable for Percy to think of as a "difference".

iPhone X
![Screen Shot 2019-07-19 at 8 01 29 AM](https://user-images.githubusercontent.com/34924300/61539570-6b18fe00-aa01-11e9-8b55-d499f91a7715.png)

iPhone 6s
![Screen Shot 2019-07-19 at 8 00 47 AM](https://user-images.githubusercontent.com/34924300/61539583-710edf00-aa01-11e9-88e1-0217e4e3ea85.png)
