### PR TITLE
fix: Add options for custom css

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,12 +30,14 @@ Webdriver.prototype.percySnapshot = async function percySnapshot(name, options =
   const base64Data = rawBase64Data.replace(/([ \r\n]+)/g, '');
 
   // Create styles for a DOM element that will render the screenshot
+  // `customCss` needs to be configured similar to below. (ex: `margin: 10px;`)
   const css = `
     background-image: url('data:image/png;base64,${base64Data}');
     background-repeat: no-repeat;
     background-size: contain;
     height: ${dimensions.height}px;
     width: ${dimensions.width}px;
+    ${options.customCss}
   `;
 
   // Percy Agent and JSDOM don't play nicely together if you try to use a


### PR DESCRIPTION
(take 2)
This adds the option to modify the screenshot to cut off the status bar.

If you wanted to do this via apple you'd have to [set the preference in a the `info.plist` when you build the app.] To circumvent this, I added some easy margin to push the taken screenshot up thus pushing the status bar out of view and adds one less variable for Percy to think of as a "difference".

![Screen Shot 2019-07-19 at 8 01 29 AM](https://user-images.githubusercontent.com/34924300/61539570-6b18fe00-aa01-11e9-8b55-d499f91a7715.png)