### PR TITLE
feat: Add percy specific snapshot option

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,12 @@ Webdriver.prototype.percySnapshot = async function percySnapshot(name, options =
     ${options.customCss}
   `;
 
+  if (options.customCss) {
+    console.warning(
+      `The "customCss" option has been deprecated in favor of "percyCSS" (used in the ${name} snapshot). "customCss"" will be removed in future versions.`
+    );
+  }
+
   // Percy Agent and JSDOM don't play nicely together if you try to use a
   // <style> tag in the document, but using inline styles seems to work
   const inlineStyle = css.replace(/([\s]*)\n([\s]*)/g, '');
@@ -86,7 +92,8 @@ Webdriver.prototype.percySnapshot = async function percySnapshot(name, options =
     environmentInfo,
     url: 'http://localhost/',
     widths: [dimensions.width],
-    minHeight: dimensions.height
+    minHeight: dimensions.height,
+    percyCSS: options.percyCSS
   });
 
   if (!postSuccess) {


### PR DESCRIPTION
## What is this?

This PR introduces the new `percyCSS` snapshot option that `@percy/agent` now supports. This PR also deprecates the `customCss` option in favor of `percyCSS` since they both do the same job. 

See: percy/percy-agent#346